### PR TITLE
:sparkles: Introduce Kedro FastAPI Server

### DIFF
--- a/kedro_boot/app/booter.py
+++ b/kedro_boot/app/booter.py
@@ -1,4 +1,4 @@
-"""A factory funtion for creating kedro boot session within external apps"""
+"""A factory funtion for creating kedro boot session within standalone apps"""
 
 from pathlib import Path
 from typing import List, Optional, Union

--- a/kedro_boot/app/fastapi/__init__.py
+++ b/kedro_boot/app/fastapi/__init__.py
@@ -1,0 +1,2 @@
+from .app import FastApiApp  # noqa: F401
+from .session import KedroFastApi  # noqa: F401

--- a/kedro_boot/app/fastapi/app.py
+++ b/kedro_boot/app/fastapi/app.py
@@ -1,0 +1,104 @@
+import logging
+import platform
+
+import uvicorn
+from kedro.config import MissingConfigException
+from kedro.utils import load_obj
+from pyctuator.pyctuator import Pyctuator
+
+from kedro_boot.app.fastapi.session import KedroFastApiSession, kedro_fastapi_session
+from kedro_boot.app import AbstractKedroBootApp
+from kedro_boot.framework.session import KedroBootSession
+
+LOGGER = logging.getLogger(__name__)
+
+
+class FastApiApp(AbstractKedroBootApp):
+    LAZY_COMPILE = True
+
+    def load_app(self, app: str):
+        app_class = app or "kedro_boot.app.fastapi.starter_apps.runner.app"
+
+        return load_obj(app_class)
+
+    def get_configs(self, server_cli_options: dict, server_file_options: dict):
+        server_options = {"host": "127.0.0.1", "port": 8000, "workers": 1}
+
+        server_cli_options = {
+            k: v for k, v in server_cli_options.items() if v is not None
+        }
+
+        server_options.update(server_file_options)
+        server_options.update(server_cli_options)
+
+        return server_options
+
+    def _run(self, kedro_boot_session: KedroBootSession):
+        try:
+            server_file_options = kedro_boot_session.config_loader["fastapi"].get(
+                "server"
+            )
+        except MissingConfigException:
+            LOGGER.warning(
+                "No 'fastapi.yml' nor 'fastapi.yaml' config file found in environment. Default configuration will be used"
+            )
+            server_file_options = {}
+
+        configs = self.get_configs(
+            server_cli_options=kedro_boot_session.app_runtime_params,
+            server_file_options=server_file_options,
+        )
+        app = self.load_app(configs.pop("app", None))
+
+        Pyctuator(
+            app,
+            "Kedro FastAPI Pyctuator",
+            app_url=None,
+            pyctuator_endpoint_url="/actuator",
+            registration_url=None,
+        )
+
+        if platform.system().lower() == "windows":
+            LOGGER.info(
+                "You are using Windows OS. uvicorn will be used as web server. Multiple workers are not supported with this setup. Please consider using Linux or Mac OS as it leverage Gunicorn capabilities."
+            )
+
+            if configs.get("workers"):
+                LOGGER.warning(
+                    "kedro-boot fastapi does not support multiple workers config in Windows OS, we'll use just one uvicorn worker. Please consider using Linux or Mac as it leverage Gunicorn capabilities"
+                )
+                configs.pop("workers")
+
+            configs.update(configs.get("extra_uvicorn", {}))
+            if configs.get("extra_uvicorn"):
+                configs.pop("extra_uvicorn")
+
+            kedro_fastapi_materialized_session = KedroFastApiSession(kedro_boot_session)
+            kedro_fastapi_materialized_session.compile(app)
+            app.dependency_overrides[
+                kedro_fastapi_session
+            ] = kedro_fastapi_materialized_session
+
+            uvicorn.run(app=app, **configs)
+
+        else:
+            from .gunicorn import GunicornApp
+
+            LOGGER.info("You are using Linux OS. Gunicorn will be used as web server")
+
+            configs["bind"] = f"{configs.get('host')}:{configs.get('port')}"
+            configs["worker_class"] = "uvicorn.workers.UvicornH11Worker"
+            configs.update(configs.get("extra_gunicorn", {}))
+
+            if configs.get("extra_gunicorn"):
+                configs.pop("extra_gunicorn")
+            if configs.get("host"):
+                configs.pop("host")
+            if configs.get("port"):
+                configs.pop("port")
+
+            app.dependency_overrides[kedro_fastapi_session] = KedroFastApiSession(
+                kedro_boot_session
+            )
+
+            GunicornApp(app, configs).run()

--- a/kedro_boot/app/fastapi/cli.py
+++ b/kedro_boot/app/fastapi/cli.py
@@ -1,0 +1,17 @@
+import click
+from kedro_boot.app.fastapi import FastApiApp
+from kedro_boot.framework.cli import kedro_boot_command_factory
+
+app_params = [
+    click.option("--app", type=str, help="fastapi app"),
+    click.option("--host", type=str, help="fastapi host"),
+    click.option("--port", type=int, help="fastapi port"),
+    click.option("--workers", type=int, help="number of workers"),
+]
+
+fastapi_command = kedro_boot_command_factory(
+    command_name="fastapi",
+    command_help="Serve a kedro pipeline using a fastapi app",
+    app_class=FastApiApp,
+    command_params=app_params,
+)

--- a/kedro_boot/app/fastapi/gunicorn/__init__.py
+++ b/kedro_boot/app/fastapi/gunicorn/__init__.py
@@ -1,0 +1,1 @@
+from .app import GunicornApp  # noqa: F401

--- a/kedro_boot/app/fastapi/gunicorn/app.py
+++ b/kedro_boot/app/fastapi/gunicorn/app.py
@@ -1,0 +1,37 @@
+import sys
+
+from gunicorn.app.wsgiapp import WSGIApplication
+
+
+class GunicornApp(WSGIApplication):
+    def __init__(self, app, options=None):
+        self.options = options or {}
+        self.application = app
+        super().__init__()
+
+    def load_config(self):
+        configs = {
+            key: value
+            for key, value in self.options.items()
+            if key in self.cfg.settings and value is not None
+        }
+        for key, value in configs.items():
+            self.cfg.set(key.lower(), value)
+
+        from . import config
+
+        cfg = vars(config)
+
+        for k, v in cfg.items():
+            # Ignore unknown names
+            if k not in self.cfg.settings:
+                continue
+            try:
+                self.cfg.set(k.lower(), v)
+            except Exception:
+                print("Invalid value for %s: %s \n" % (k, v), file=sys.stderr)
+                sys.stderr.flush()
+                raise
+
+    def load(self):
+        return self.application

--- a/kedro_boot/app/fastapi/gunicorn/config.py
+++ b/kedro_boot/app/fastapi/gunicorn/config.py
@@ -1,0 +1,14 @@
+# from .utils import get_routes_data_models
+import logging
+
+from kedro_boot.app.fastapi.session import kedro_fastapi_session
+
+LOGGER = logging.getLogger(__name__)
+
+
+def post_worker_init(worker):
+    fastapi_app = worker.app.wsgi()
+    fastapi_app.dependency_overrides[kedro_fastapi_session].compile(fastapi_app)
+    LOGGER.info(
+        "Kedro Boot Catalog compilation is completed. Ready to serve your app !"
+    )

--- a/kedro_boot/app/fastapi/session.py
+++ b/kedro_boot/app/fastapi/session.py
@@ -1,0 +1,139 @@
+import inspect
+import logging
+import threading
+import typing
+import uuid
+
+try:  # For backward compatibility with python 3.8
+    from typing import Annotated
+except ImportError:
+    from typing_extensions import Annotated
+
+from fastapi import Depends, FastAPI, Request
+
+from kedro_boot.framework.compiler.specs import CompilationSpec
+from kedro_boot.framework.session import KedroBootSession
+
+LOGGER = logging.getLogger(__name__)
+
+
+class KedroFastApiSession:
+    def __init__(self, session: KedroBootSession = None) -> None:
+        self.session = session
+
+    async def __call__(self, request: Request):
+        itertime_params = request.path_params
+        parameters = request.query_params._dict
+        namespace = request.scope["route"].operation_id
+        datasets = {}
+
+        # TODO: We should get pipeline inputs and outputs from CompilationSpec instead. We should persist it after compilation.
+
+        pipeline_inputs = self.session._context.get_inputs_datasets(namespace)
+
+        if pipeline_inputs:
+            datasets = await request.json()
+            if len(pipeline_inputs) == 1:
+                datasets = {pipeline_inputs[0]: datasets}
+
+        run_id = uuid.uuid4().hex
+        itertime_params.update({"run_id": run_id})
+
+        pipeline_outputs = self.session._context.get_outputs_datasets(namespace)
+        if (
+            inspect.iscoroutinefunction(request.scope["endpoint"])
+            and not pipeline_outputs
+        ):
+            LOGGER.info(f"Running {request.scope['endpoint'].__name__} in background")
+            background_thread = threading.Thread(
+                target=self.session.run,
+                args=(namespace, datasets, parameters, itertime_params, run_id),
+            )
+            background_thread.start()
+            return {
+                "message": f"Running {request.scope['endpoint'].__name__} in background. You can refer to the resource details to identify the logs and get the run state",
+                "resource": {
+                    "run_id": run_id,
+                    "namespace": namespace or "None",
+                    "parameters": parameters,
+                    "itertime_params": itertime_params,
+                },
+            }
+
+        return self.session.run(
+            namespace=namespace,
+            inputs=datasets,
+            parameters=parameters,
+            itertime_params=itertime_params,
+            run_id=run_id,
+        )
+
+    def compile(self, app: FastAPI) -> None:
+        compilation_specs = []
+
+        for route in app.routes:
+            if hasattr(route, "endpoint") and hasattr(
+                route.endpoint, "__annotations__"
+            ):
+                managed_endpoints = {
+                    endpoint_name: endpoint_type
+                    for endpoint_name, endpoint_type in route.endpoint.__annotations__.items()
+                    if KedroFastApi == endpoint_type
+                }
+
+                if managed_endpoints:
+                    compilation_specs_inputs = []
+                    compilation_specs_outputs = []
+
+                    for (
+                        param_name,
+                        param_type,
+                    ) in route.endpoint.__annotations__.items():
+                        encapsuled_managed_type = [
+                            type
+                            for type in typing.get_args(param_type)
+                            if type.__class__.__name__ == "ModelMetaclass"
+                        ]
+                        if encapsuled_managed_type:
+                            if param_type.__name__ == "List":
+                                managed_type = typing.get_args(param_type)[0]
+                            else:
+                                raise KedroFastApiSessionError(
+                                    f"Only List type is authourized to encapsul a managed request body Data Model. We got {param_type} for {route.endpoint.__name__} endpoint"
+                                )
+                        else:
+                            managed_type = param_type
+                        if (
+                            managed_type.__class__.__name__ == "ModelMetaclass"
+                            and param_name == "return"
+                        ):
+                            compilation_specs_outputs.append(route.endpoint.__name__)
+
+                        elif managed_type.__class__.__name__ == "ModelMetaclass":
+                            compilation_specs_inputs.append(param_name)
+
+                    if (
+                        inspect.iscoroutinefunction(route.endpoint)
+                        and compilation_specs_outputs
+                    ):
+                        LOGGER.warning(
+                            f"We cannot declare {route.endpoint.__name__} endpoint as async while waiting reponse data from pipeline's {compilation_specs_outputs} outputs. We gonna switch to sync mode"
+                        )
+
+                    compilation_specs.append(
+                        CompilationSpec(
+                            namespace=route.operation_id,
+                            inputs=compilation_specs_inputs,
+                            outputs=compilation_specs_outputs,
+                        )
+                    )
+
+        self.session.compile(compilation_specs=compilation_specs)
+
+
+kedro_fastapi_session = KedroFastApiSession()
+KedroFastApi = Annotated[dict, Depends(kedro_fastapi_session)]
+
+
+class KedroFastApiSessionError(Exception):
+    """Error raised in catalog rendering operations"""

--- a/kedro_boot/app/fastapi/starter_apps/runner.py
+++ b/kedro_boot/app/fastapi/starter_apps/runner.py
@@ -1,0 +1,10 @@
+from fastapi import FastAPI
+
+from kedro_boot.app.fastapi import KedroFastApi
+
+app = FastAPI()
+
+
+@app.get("/run", tags=["Run Pipeline"])
+def run_pipeline(run_results: KedroFastApi):
+    return run_results

--- a/kedro_boot/framework/cli/factory.py
+++ b/kedro_boot/framework/cli/factory.py
@@ -73,12 +73,6 @@ def create_kedro_booter(
             **kedro_session_create_args,  # TODO: Make sure that this not take precedence over kedro_args. We should do some prior merging before kwarging
         ) as session:
             config_loader = session._get_config_loader()
-            config_loader._register_new_resolvers(
-                {
-                    "itertime_params": lambda variable,
-                    default_value=None: f"${{oc.select:{variable},{default_value}}}",
-                }
-            )
             if app:
                 runner = KedroBootAdapter(
                     app=app,

--- a/kedro_boot/framework/context/context.py
+++ b/kedro_boot/framework/context/context.py
@@ -72,6 +72,10 @@ class KedroBootContext:
                 ]
             )
 
+            if given_namespaces - infered_namespaces:
+                raise KedroBootContextError(
+                    f"The given namespaces does not match with any of the pipeline namespaces. pipeline namespace are {infered_namespaces}, and the given namespaces are {given_namespaces}"
+                )
             if given_namespaces != infered_namespaces:
                 LOGGER.warning(
                     f"The given namespaces does not match with the pipeline namespaces. pipeline namespace are {infered_namespaces}, and the given namespaces are {given_namespaces}"
@@ -87,6 +91,8 @@ class KedroBootContext:
             pipeline = filter_pipeline(
                 pipeline=self.pipeline, namespace=compilation_spec.namespace
             )
+            # if not pipeline.nodes:
+            #     raise KedroBootContextError(f"The {compilation_spec.namespace} namespace contains no nodes")
 
             pipeline_inputs = {
                 dataset_name: self.catalog._get_dataset(dataset_name)
@@ -155,6 +161,7 @@ class KedroBootContext:
                 pipeline=pipeline,
                 catalog=catalog_assembly,
                 outputs=compilation_spec.namespaced_outputs,
+                inputs=compilation_spec.inputs,
             )
 
         LOGGER.info("Loading artifacts datasets as MemoryDataset ...")
@@ -254,6 +261,9 @@ class KedroBootContext:
 
     def get_outputs_datasets(self, namespace: str) -> List[str]:
         return self._namespaces_registry.get(namespace).get("outputs")
+
+    def get_inputs_datasets(self, namespace: str) -> List[str]:
+        return self._namespaces_registry.get(namespace).get("inputs")
 
 
 def namespace_datasets(iteration_datasets: dict, namespace: str = None) -> dict:

--- a/kedro_boot/framework/hooks.py
+++ b/kedro_boot/framework/hooks.py
@@ -1,0 +1,26 @@
+from kedro.framework.hooks import hook_impl
+from kedro.framework.context import KedroContext
+
+
+class KedroBootHook:
+    @hook_impl
+    def after_context_created(
+        self,
+        context: KedroContext,
+    ) -> None:
+        """Hooks to be invoked after a `KedroContext` is created. This is the earliest
+        hook triggered within a Kedro run. The `KedroContext` stores useful information
+        such as `credentials`, `config_loader` and `env`.
+        Args:
+            context: The context that was created.
+        """
+
+        context.config_loader._register_new_resolvers(
+            {
+                "itertime_params": lambda variable,
+                default_value=None: f"${{oc.select:{variable},{default_value}}}",
+            }
+        )
+
+
+kedro_boot_hook = KedroBootHook()

--- a/setup.py
+++ b/setup.py
@@ -52,9 +52,18 @@ setup(
             "pre-commit>=2.0.0,<4.0.0",
             "jupyter>=1.0.0,<2.0.0",
         ],
+        "fastapi": [
+            "fastapi>=0.100.0",
+            "gunicorn==21.2.0",
+            "pyctuator==0.18.1",
+        ],
     },
     entry_points={
-        "kedro.project_commands": ["boot =  kedro_boot.framework.cli.cli:commands"]
+        "kedro.project_commands": ["boot =  kedro_boot.framework.cli.cli:commands"],
+        "kedro_boot": ["fastapi = kedro_boot.app.fastapi.cli:fastapi_command"],
+        "kedro.hooks": [
+            "kedro_boot_hook = kedro_boot.framework.hooks:kedro_boot_hook",
+        ],
     },
     keywords="kedro-plugin, framework, data apps, pipelines, machine learning, data pipelines, data science, data engineering, model serving, mlops, dataops",
     classifiers=[


### PR DESCRIPTION
Introduce a framework for serving kedro pipelines. It uses FastAPI APIs as user interfaces for developping declaratively the serving endpoints. 
Under the hood it's a Kedro Boot App that generate it's own compilation specs from the FastApi app object. The FastAPI app object is also used to map FastAPI object with kedro's objects (request data with kedro params and datasets)