### PR TITLE
🐛⬆️ fix kedro boot commands by supporting kedro 0.19.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,19 @@
 
 ## [Unreleased]
 
+### Added
+
+- :sparkles: Kedro Boot commands now works inside a subdirectory
+
+### Fixed
+
+- :bug: Fix Kedro Boot commands by supporting kedro 0.19.4 breaking changes of the ``_is_project`` utility 
+
 ## [0.2.1] - 2024-02-13
 
 ### Added
 
--   :sparkles: Include ["fastapi*/] dynamically in the config loader config patterns
+- :sparkles: Include ["fastapi*/] dynamically in the config loader config patterns
 
 ### Fixed
 

--- a/kedro_boot/framework/cli/cli.py
+++ b/kedro_boot/framework/cli/cli.py
@@ -2,9 +2,8 @@
 import click
 import logging
 from pathlib import Path
-from kedro.framework.startup import _is_project
 from .factory import kedro_boot_command_factory
-from .utils import get_entry_points_commands
+from .utils import get_entry_points_commands, _is_project, _find_kedro_project
 
 LOGGER = logging.getLogger(__name__)
 
@@ -27,7 +26,7 @@ class KedroClickGroup(click.Group):
         self.commands = {}
 
         # add commands on the fly based on conditions
-        if _is_project(Path.cwd()):
+        if _is_project(_find_kedro_project(Path.cwd()) or Path.cwd()):
             self.add_command(run_command)
             self.add_command(compile_command)
             for entry_point_command in entry_points_commands:

--- a/kedro_boot/framework/cli/utils.py
+++ b/kedro_boot/framework/cli/utils.py
@@ -1,5 +1,7 @@
 import importlib_metadata
 import logging
+from typing import Union, Any
+from pathlib import Path
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,3 +28,23 @@ def get_entry_points_commands(entry_point_key):
             entry_point_commands.append(loaded_entry_point)
 
     return entry_point_commands
+
+
+def _is_project(project_path: Union[str, Path]) -> bool:
+    try:
+        # for retrocompatiblity with kedro >=0.19.0,<0.19.3
+        from kedro.framework.startup import _is_project as _ip
+    except ImportError:
+        from kedro.utils import _is_project as _ip
+
+    return _ip(project_path)
+
+
+def _find_kedro_project(current_dir: Path) -> Any:
+    try:
+        # for retrocompatiblity with kedro >=0.19.0,<0.19.3
+        from kedro.framework.startup import _find_kedro_project as _fkp
+    except ImportError:
+        from kedro.utils import _find_kedro_project as _fkp
+
+    return _fkp(current_dir)


### PR DESCRIPTION
Fix kedro boot commands by supporting kedro 0.19.4 breaking changes of the ``_is_project`` utility 