### PR TITLE
:bug: Fix Kedro 0.19.11 incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- :bug: Fix Kedro 0.19.11 incompatibility by implementing the new `_get_executor` AbstractRunner method in the `KedroBootAdapter` 
+
 ## [0.2.3] - 2024-11-15
 
 ### Added

--- a/kedro_boot/framework/adapter.py
+++ b/kedro_boot/framework/adapter.py
@@ -1,4 +1,5 @@
 """``KedroBootAdapter`` transform a Kedro Session Run to a booting process."""
+from concurrent.futures import Executor
 import logging
 from typing import Any, Optional, Union
 
@@ -37,6 +38,10 @@ class KedroBootAdapter(AbstractRunner):
         self._app = app
         self._config_loader = config_loader
         self._app_runtime_params = app_runtime_params or {}
+
+    def _get_executor(self, max_workers: int) -> Executor:
+        """Abstract method to provide the correct executor (e.g., ThreadPoolExecutor or ProcessPoolExecutor)."""
+        pass
 
     def run(
         self,


### PR DESCRIPTION
:bug: Fix Kedro 0.19.11 incompatibility by implementing the new `_get_executor` AbstractRunner method in the `KedroBootAdapter`  

close #40 